### PR TITLE
Adding 'mapActionsAs' to store

### DIFF
--- a/src/Hooks/Reducer/AddTodo.js
+++ b/src/Hooks/Reducer/AddTodo.js
@@ -5,13 +5,16 @@ import { useStore } from './store';
 import { addTodo } from '../../state/actions';
 
 const AddTodo = () => {
-  const dispatch = useStore()[1];
+  const actionCreators = useStore(undefined, {
+    addTodo
+  })[1];
 
   const { values, handleChange, reset } = useForm();
 
   const handleSubmit = event => {
     event.preventDefault();
-    dispatch(addTodo(values));
+    // dispatch(addTodo(values));
+    actionCreators.addTodo(values);
     reset();
   };
 

--- a/src/Hooks/Reducer/store.js
+++ b/src/Hooks/Reducer/store.js
@@ -116,10 +116,10 @@ export const useStore = (...maps) => {
   dispatcher = actionCreator => {
     if (actionCreator instanceof Promise) {
       Promise.all([actionCreator]).then(([action]) => {
-        __dispatch(action);
         if (__enableDebug) {
           __setAction(action);
         }
+        __dispatch(action);
       });
     } else {
       __dispatch(actionCreator);

--- a/src/Hooks/Reducer/store.js
+++ b/src/Hooks/Reducer/store.js
@@ -28,21 +28,13 @@ export const Provider = ({ children, state, reducer, enableDebug }) => {
 
   useEffect(() => {
     if (enableDebug) {
-      if (
-        window.__REDUX_DEVTOOLS_EXTENSION__ &&
-        window.__REDUX_DEVTOOLS_EXTENSION__.send &&
-        typeof window.__REDUX_DEVTOOLS_EXTENSION__.send === 'function'
-      ) {
-        window.__REDUX_DEVTOOLS_EXTENSION__.send(store.__action, getClearState(store));
-      } else {
-        console.log(
-          `%cAction: %c${JSON.stringify(store.__action)} |  %cState: %c${JSON.stringify(getClearState(store))}`,
-          'font-weight:bold; color: green; font-size: 15px;',
-          'color: black; font-size: 15px;',
-          'font-weight:bold; color: blue; font-size: 15px;',
-          'color: black; font-size: 15px;'
-        );
-      }
+      console.log(
+        `%cAction: %c${JSON.stringify(store.__action)} |  %cState: %c${JSON.stringify(getClearState(store))}`,
+        'font-weight:bold; color: green; font-size: 15px;',
+        'color: black; font-size: 15px;',
+        'font-weight:bold; color: blue; font-size: 15px;',
+        'color: black; font-size: 15px;'
+      );
     }
   }, [store]);
 
@@ -65,7 +57,7 @@ export const useStoreCreator = (initialState, reducer) => {
     initialState,
     reducer
   });
-  const ACTION_TYPE = '';
+  const ACTION_TYPE = '@@INIT_STATE';
   const [store, dispatch] = useReducer(reducer, reducer(initialState, { ACTION_TYPE }));
   const [action, setAction] = useState(ACTION_TYPE);
 

--- a/src/Hooks/Reducer/store.js
+++ b/src/Hooks/Reducer/store.js
@@ -28,13 +28,21 @@ export const Provider = ({ children, state, reducer, enableDebug }) => {
 
   useEffect(() => {
     if (enableDebug) {
-      console.log(
-        `%cAction: %c${JSON.stringify(store.__action)} |  %cState: %c${JSON.stringify(getClearState(store))}`,
-        'font-weight:bold; color: green; font-size: 15px;',
-        'color: black; font-size: 15px;',
-        'font-weight:bold; color: blue; font-size: 15px;',
-        'color: black; font-size: 15px;'
-      );
+      if (
+        window.__REDUX_DEVTOOLS_EXTENSION__ &&
+        window.__REDUX_DEVTOOLS_EXTENSION__.send &&
+        typeof window.__REDUX_DEVTOOLS_EXTENSION__.send === 'function'
+      ) {
+        window.__REDUX_DEVTOOLS_EXTENSION__.send(store.__action, getClearState(store));
+      } else {
+        console.log(
+          `%cAction: %c${JSON.stringify(store.__action)} |  %cState: %c${JSON.stringify(getClearState(store))}`,
+          'font-weight:bold; color: green; font-size: 15px;',
+          'color: black; font-size: 15px;',
+          'font-weight:bold; color: blue; font-size: 15px;',
+          'color: black; font-size: 15px;'
+        );
+      }
     }
   }, [store]);
 
@@ -57,7 +65,7 @@ export const useStoreCreator = (initialState, reducer) => {
     initialState,
     reducer
   });
-  const ACTION_TYPE = '@@INIT_STATE';
+  const ACTION_TYPE = '';
   const [store, dispatch] = useReducer(reducer, reducer(initialState, { ACTION_TYPE }));
   const [action, setAction] = useState(ACTION_TYPE);
 

--- a/src/state/actions.js
+++ b/src/state/actions.js
@@ -1,9 +1,24 @@
 import { ADD_TODO, DELETE_TODO } from './action-types';
 
-export const addTodo = ({ todo }) => ({
-  type: ADD_TODO,
-  label: todo
-});
+const timeout = ms => {
+  return new Promise(resolve => setTimeout(resolve(), ms));
+};
+
+export const addTodo = async ({ todo }) => {
+  const action = {
+    type: ADD_TODO,
+    label: todo
+  };
+
+  // return new Promise(resolve => {
+  //   setTimeout(() => {
+  //     resolve(action);
+  //   }, 500);
+  // });
+
+  await timeout(500);
+  return action;
+};
 
 export const deleteTodo = id => ({
   type: DELETE_TODO,


### PR DESCRIPTION
I've added the option to pass 'mapActionsAs' to the useStore.
it must be an object of actionCreators. if the action creator is async / return a promise, use the promise.all to dispatch the resulted action. otherwise I will just dispatch it.

You can see the example I've used in the addToDo. 